### PR TITLE
Change TA Variable on Form So /new Renders

### DIFF
--- a/app/views/teaching_assistants/_form.html.erb
+++ b/app/views/teaching_assistants/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @teaching_assistant, html: { class: 'form-horizontal' } do |f| %>
+<%= form_for @ta, html: { class: 'form-horizontal' } do |f| %>
   <div class="form-group">
     <%= f.label :name, 'First and last name', class: 'col-lg-3 control-label' %>
     <div class="col-lg-9">


### PR DESCRIPTION
Fixes `/teaching_assistants/new` not rendering

I noticed the route http://gdichicago.herokuapp.com/teaching_assistants/new was not rendering:

![image](https://cloud.githubusercontent.com/assets/2359538/25559143/2c34814e-2cfb-11e7-92ac-9f3c2a5a4ac4.png)

The error locally:

`First argument in form cannot contain nil or be empty`

![image](https://cloud.githubusercontent.com/assets/2359538/25559144/38f00e3a-2cfb-11e7-892f-b151812f8948.png)

I think the issue is the TA form was using the wrong instance variable. Changing this variable allows the `/teaching_assistants/new` route to render locally